### PR TITLE
Modify function entry names in bls.toml

### DIFF
--- a/bls.toml
+++ b/bls.toml
@@ -7,10 +7,10 @@ nodes = 1
 
 [build]
 dir = "build"
-entry = "template_name-debug.wasm"
+entry = "template_name_debug.wasm"
 command = "npm run build:debug"
 
 [build_release]
 dir = "build"
-entry = "template_name-release.wasm"
+entry = "template_name.wasm"
 command = "npm run build:release"


### PR DESCRIPTION
This change standardizes the naming structure with bls.toml files generated by the CLI. 
'-release' is no longer required and '-debug' suffix has changed to '_debug'
