### PR TITLE
Include content write permission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,14 @@ on:
   workflow_dispatch:
   repository_dispatch:
 
-permissions:
-  contents: write
-  
 jobs:
   publish-on-blockless:
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: write  # This is required for actions/checkout
+
     steps:
       - uses: actions/checkout@v2
       - name: get epository name
@@ -19,7 +21,5 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
       - name: Blockless Action Setup
         uses: txlabs/github-action-blockless-setup@v0.0.4
-        with:
-          BLOCKLESS_ACCESS_TOKEN: ${{ secrets.BLOCKLESS_ACCESS_TOKEN }}
       - name: Blockless Function Publish
         uses: txlabs/github-action-blockless-deploy@v0.0.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   repository_dispatch:
 
+permissions:
+  contents: write
+  
 jobs:
   publish-on-blockless:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR address two issues: 
1. Allowing permissions for Github OIDC token swaps.
2. Allowing auto commit to run on repositories without global workflow write permissions.