### PR TITLE
Bump version to v0.0.5 for blockless-setup action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,6 @@ jobs:
           cat bls.toml
       - uses: stefanzweifel/git-auto-commit-action@v4
       - name: Blockless Action Setup
-        uses: txlabs/github-action-blockless-setup@v0.0.4
+        uses: txlabs/github-action-blockless-setup@v0.0.5
       - name: Blockless Function Publish
         uses: txlabs/github-action-blockless-deploy@v0.0.3


### PR DESCRIPTION
This is version change will allow github actions to authenticate via Github OIDC and no longer require a JWT secret.